### PR TITLE
add Smarty template tokenizer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -29,13 +29,14 @@ Symfony\CS\Fixer\Contrib\HeaderCommentFixer::setHeader($header);
 $finder = Symfony\CS\Finder\DefaultFinder::create()
 	->in(__DIR__)
 	->exclude('vendor')
+	->exclude('templates_c')
 ;
 
 return Symfony\CS\Config\Config::create()
 	->setUsingCache(true)
 	->level(Symfony\CS\FixerInterface::NONE_LEVEL)
 	->fixers(array(
-		'linefeed', 'trailing_spaces', 'unused_use', 'short_tag',
+		'linefeed', 'trailing_spaces', 'unused_use', '-short_tag',
 		'return', 'visibility', 'php_closing_tag', 'extra_empty_lines',
 		'function_declaration', 'include', 'controls_spaces', 'elseif',
 		'-eof_ending',

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,8 @@
 	},
 	"require": {
 		"php": "^5.3 || ^7.0",
+		"smarty-gettext/smarty-gettext": "~1.5.0",
+		"smarty/smarty": "~3.1",
 		"symfony/console": "~2.8|~3.0",
 		"symfony/finder": "~2.8|~3.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 	"require": {
 		"php": "^5.3 || ^7.0",
 		"smarty-gettext/smarty-gettext": "~1.5.0",
-		"smarty/smarty": "~3.1",
+		"smarty/smarty": "~3.1.31",
 		"symfony/console": "~2.8|~3.0",
 		"symfony/finder": "~2.8|~3.0"
 	},

--- a/src/Console/Command/Extract.php
+++ b/src/Console/Command/Extract.php
@@ -68,7 +68,7 @@ EOT
 			if (is_dir($arg)) {
 				$finder->in($arg);
 			} elseif (is_file($arg)) {
-				$files[] = new SplFileInfo($arg,null, null);
+				$files[] = new SplFileInfo($arg, null, null);
 			} else {
 				throw new InvalidArgumentException("Not file or dir: $arg");
 			}

--- a/src/Tokenizer/Token/Tag.php
+++ b/src/Tokenizer/Token/Tag.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Tokenizer\Token;
+
+class Tag {
+	/** @var string */
+	public $name;
+
+	/** @var string[] */
+	public $arguments;
+
+	public function __construct($name, $arguments) {
+		$this->name = $name;
+		$this->arguments = $arguments;
+	}
+}

--- a/src/Tokenizer/Token/Tag.php
+++ b/src/Tokenizer/Token/Tag.php
@@ -15,13 +15,17 @@
 namespace SmartyGettext\Tokenizer\Token;
 
 class Tag {
+	/** @var int */
+	public $line;
+
 	/** @var string */
 	public $name;
 
 	/** @var string[] */
 	public $arguments;
 
-	public function __construct($name, $arguments) {
+	public function __construct($line, $name, $arguments) {
+		$this->line = $line;
 		$this->name = $name;
 		$this->arguments = $arguments;
 	}

--- a/src/Tokenizer/Token/Text.php
+++ b/src/Tokenizer/Token/Text.php
@@ -15,10 +15,14 @@
 namespace SmartyGettext\Tokenizer\Token;
 
 class Text {
+	/** @var int */
+	public $line;
+
 	/** @var string */
 	public $text;
 
-	public function __construct($text) {
+	public function __construct($line, $text) {
+		$this->line = $line;
 		$this->text = $text;
 	}
 }

--- a/src/Tokenizer/Token/Text.php
+++ b/src/Tokenizer/Token/Text.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Tokenizer\Token;
+
+class Text {
+	/** @var string */
+	public $text;
+
+	public function __construct($text) {
+		$this->text = $text;
+	}
+}

--- a/src/Tokenizer/TokenCollector.php
+++ b/src/Tokenizer/TokenCollector.php
@@ -34,7 +34,7 @@ class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	 * {@inheritdoc}
 	 */
 	public function compileTag($tag, $args, $parameter = array()) {
-		$line = $this->parser->lex->line;
+		$line = $this->parser->lex->taglineno;
 		$this->tokens[] = new Token\Tag($line, $tag, $args, $parameter);
 
 		return parent::compileTag($tag, $args, $parameter);
@@ -44,7 +44,7 @@ class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	 * {@inheritdoc}
 	 */
 	public function processText($text) {
-		$line = $this->parser->lex->line;
+		$line = $this->parser->lex->taglineno;
 		$this->tokens[] = new Token\Text($line, $text);
 
 		return parent::processText($text);

--- a/src/Tokenizer/TokenCollector.php
+++ b/src/Tokenizer/TokenCollector.php
@@ -34,7 +34,9 @@ class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	 * {@inheritdoc}
 	 */
 	public function compileTag($tag, $args, $parameter = array()) {
-		self::$tokens[] = new Token\Tag($tag, $args, $parameter);
+		$line = $this->parser->lex->line;
+
+		self::$tokens[] = new Token\Tag($line, $tag, $args, $parameter);
 
 		return parent::compileTag($tag, $args, $parameter);
 	}
@@ -43,7 +45,9 @@ class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	 * {@inheritdoc}
 	 */
 	public function processText($text) {
-		self::$tokens[] = new Token\Text($text);
+		$line = $this->parser->lex->line;
+
+		self::$tokens[] = new Token\Text($line, $text);
 
 		return parent::processText($text);
 	}

--- a/src/Tokenizer/TokenCollector.php
+++ b/src/Tokenizer/TokenCollector.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Tokenizer;
+
+use Smarty_Internal_SmartyTemplateCompiler;
+
+/**
+ * Wrapper to grab tokens from Smarty Template Compiler as they get parsed from template.
+ */
+class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
+	/** @var array */
+	private static $tokens = array();
+
+	/**
+	 * @return array
+	 */
+	public static function getTokens() {
+		return self::$tokens;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function compileTag($tag, $args, $parameter = array()) {
+		self::$tokens[] = new Token\Tag($tag, $args, $parameter);
+
+		return parent::compileTag($tag, $args, $parameter);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function processText($text) {
+		self::$tokens[] = new Token\Text($text);
+
+		return parent::processText($text);
+	}
+}

--- a/src/Tokenizer/TokenCollector.php
+++ b/src/Tokenizer/TokenCollector.php
@@ -21,13 +21,13 @@ use Smarty_Internal_SmartyTemplateCompiler;
  */
 class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	/** @var array */
-	private static $tokens = array();
+	private $tokens = array();
 
 	/**
 	 * @return array
 	 */
-	public static function getTokens() {
-		return self::$tokens;
+	public function getTokens() {
+		return $this->tokens;
 	}
 
 	/**
@@ -35,8 +35,7 @@ class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	 */
 	public function compileTag($tag, $args, $parameter = array()) {
 		$line = $this->parser->lex->line;
-
-		self::$tokens[] = new Token\Tag($line, $tag, $args, $parameter);
+		$this->tokens[] = new Token\Tag($line, $tag, $args, $parameter);
 
 		return parent::compileTag($tag, $args, $parameter);
 	}
@@ -46,8 +45,7 @@ class TokenCollector extends Smarty_Internal_SmartyTemplateCompiler {
 	 */
 	public function processText($text) {
 		$line = $this->parser->lex->line;
-
-		self::$tokens[] = new Token\Text($line, $text);
+		$this->tokens[] = new Token\Text($line, $text);
 
 		return parent::processText($text);
 	}

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Tokenizer;
+
+use Smarty;
+use Smarty_Internal_SmartyTemplateCompiler;
+use Smarty_Internal_Template;
+
+class Tokenizer {
+	/** @var Smarty */
+	private $smarty;
+
+	/**
+	 * Compiler constructor.
+	 *
+	 * @param Smarty $smarty
+	 */
+	public function __construct(Smarty $smarty) {
+		$this->smarty = $smarty;
+	}
+
+	/**
+	 * @param string $templateFile
+	 * @return array
+	 */
+	public function getTokens($templateFile) {
+		/** @var Smarty_Internal_Template $template */
+		$template = $this->smarty->createTemplate($templateFile, $this->smarty);
+		$template->source->compiler_class = __NAMESPACE__ . '\\TokenCollector';
+
+		/** @var Smarty_Internal_SmartyTemplateCompiler $compiler */
+		$compiler = $template->compiler;
+		$compiler->compileTemplate($template);
+
+		return TokenCollector::getTokens();
+	}
+}

--- a/src/Tokenizer/Tokenizer.php
+++ b/src/Tokenizer/Tokenizer.php
@@ -15,7 +15,6 @@
 namespace SmartyGettext\Tokenizer;
 
 use Smarty;
-use Smarty_Internal_SmartyTemplateCompiler;
 use Smarty_Internal_Template;
 
 class Tokenizer {
@@ -40,10 +39,10 @@ class Tokenizer {
 		$template = $this->smarty->createTemplate($templateFile, $this->smarty);
 		$template->source->compiler_class = __NAMESPACE__ . '\\TokenCollector';
 
-		/** @var Smarty_Internal_SmartyTemplateCompiler $compiler */
+		/** @var TokenCollector $compiler */
 		$compiler = $template->compiler;
 		$compiler->compileTemplate($template);
 
-		return TokenCollector::getTokens();
+		return $compiler->getTokens();
 	}
 }

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -26,12 +26,15 @@ class TokenizerTest extends TestCase {
 		// {t name="sagi"}
 		$this->assertEquals('t', $tokens[1]->name);
 		$this->assertEquals('"sagi"', $tokens[1]->arguments[0]['name']);
+		$this->assertEquals(2, $tokens[1]->line);
 
 		// text content
 		$this->assertEquals('my name is %1', $tokens[2]->text);
+		$this->assertEquals(2, $tokens[2]->line);
 
 		// {/t}
 		$this->assertEquals('tclose', $tokens[3]->name);
+		$this->assertEquals(2, $tokens[3]->line);
 	}
 
 	/**

--- a/tests/TokenizerTest.php
+++ b/tests/TokenizerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Test;
+
+use Smarty;
+use SmartyGettext\Tokenizer\Tokenizer;
+
+class TokenizerTest extends TestCase {
+
+	public function test1() {
+		$tokens = $this->getTokens(__DIR__ . '/data/1.html');
+		$this->assertCount(9, $tokens);
+
+		// {t name="sagi"}
+		$this->assertEquals('t', $tokens[1]->name);
+		$this->assertEquals('"sagi"', $tokens[1]->arguments[0]['name']);
+
+		// text content
+		$this->assertEquals('my name is %1', $tokens[2]->text);
+
+		// {/t}
+		$this->assertEquals('tclose', $tokens[3]->name);
+	}
+
+	/**
+	 * @param string $template
+	 * @return array
+	 */
+	private function getTokens($template) {
+		$smarty = new Smarty();
+		$tokenizer = new Tokenizer($smarty);
+
+		return $tokenizer->getTokens($template);
+	}
+}

--- a/tests/data/1.html
+++ b/tests/data/1.html
@@ -1,0 +1,10 @@
+<html>
+For example, {t name="sagi"}my name is %1{/t} will replace %1 with sagi.
+
+The parameter name is ignored, unless it is one of the reserved
+names (see below). Only the parameters order matters.
+
+Example for using multiple parameters:
+{t 1='one' 2="two " 3=three}The 1st parameter is %1, the 2nd is %2
+and the 3nd %3.{/t}
+</html>


### PR DESCRIPTION
asked Smarty own parser/tokenizer to parse `.tpl` files: https://github.com/smarty-php/smarty/issues/364
no replies so far, so wrote my own.

- [x] parse `.tpl` into token stream
- [x] extract line number context
- [ ] process token list into usable object

NOTE: this requires that all `block` functions be available when template is parsed. for initial release `{t}` block handler is present via composer dependency.