### PR TITLE
fix line number context to be line of opening tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - define dummy plugin handlers for unknown tags, #6
 - fix plural handling, #7
+- fix line number context to be line of opening tag, #8
 
 [0.1.1]: https://github.com/smarty-gettext/tsmarty2c/compare/0.1.0...master
 

--- a/src/Tokenizer/TokenParser.php
+++ b/src/Tokenizer/TokenParser.php
@@ -52,13 +52,13 @@ class TokenParser
         $topen = null;
         foreach ($tokens as $i => $token) {
             $previous = $i > 0 ? $tokens[$i - 1] : null;
-            if ($token instanceof Token\Tag && $token->name == 't') {
+            if ($token instanceof Token\Tag && $token->name === 't') {
                 $topen = $token;
             } elseif ($topen &&
-                ($token instanceof Token\Tag && $token->name == 'tclose')
+                ($token instanceof Token\Tag && $token->name === 'tclose')
                 && $previous instanceof Token\Text
             ) {
-                $tags[] = new TranslateTag($previous->text, $topen->arguments, $token->line);
+                $tags[] = new TranslateTag($previous->text, $topen->arguments, $topen->line);
                 $topen = null;
             }
         }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -43,6 +43,54 @@ class ParserTest extends TestCase {
 		$this->assertNotNull($e->get(PoTokens::PLURAL), "has plural");
 	}
 
+	public function testLineNumbers() {
+		$fileName = __DIR__ . '/data/linenumbers.tpl';
+		$p = $this->parseTemplate($fileName);
+		$this->assertNotNull($p);
+
+		$e = $this->getEntries($p);
+		$this->assertCount(3, $e);
+
+		$refs = array(
+			"$fileName:6",
+		);
+		$this->assertReferences($refs, $e[0]);
+
+		$refs = array(
+			"$fileName:9",
+		);
+		$this->assertReferences($refs, $e[1]);
+
+		$refs = array(
+			"$fileName:13",
+		);
+		$this->assertReferences($refs, $e[2]);
+	}
+
+	/**
+	 * Assert that references are equal to expected
+	 *
+	 * @param array $expected
+	 * @param PoEntry $entry
+	 */
+	private function assertReferences($expected, PoEntry $entry) {
+		$ref = $entry->get(PoTokens::REFERENCE);
+		$this->assertCount(count($expected), $ref);
+		$this->assertEquals($expected, $ref);
+	}
+
+	/**
+	 * Flatten entries to be index based
+	 *
+	 * @param PotFile $p
+	 * @return PoEntry[]
+	 */
+	private function getEntries($p) {
+		$e = $p->getPoFile()->getEntries();
+
+		return array_values($e);
+	}
+
 	private function parseTemplate($filename) {
 		$file = new SplFileInfo($filename, $filename, $filename);
 		$p = new PotFile();

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -51,32 +51,33 @@ class ParserTest extends TestCase {
 		$e = $this->getEntries($p);
 		$this->assertCount(3, $e);
 
-		$refs = array(
-			"$fileName:6",
+		$expected = array(
+			array(
+				"$fileName:6",
+			),
+			array(
+				"$fileName:8",
+			),
+			array(
+				"$fileName:11",
+			),
 		);
-		$this->assertReferences($refs, $e[0]);
-
-		$refs = array(
-			"$fileName:9",
-		);
-		$this->assertReferences($refs, $e[1]);
-
-		$refs = array(
-			"$fileName:13",
-		);
-		$this->assertReferences($refs, $e[2]);
+		$this->assertReferences($expected, $e);
 	}
 
 	/**
 	 * Assert that references are equal to expected
 	 *
 	 * @param array $expected
-	 * @param PoEntry $entry
+	 * @param PoEntry[] $entries
 	 */
-	private function assertReferences($expected, PoEntry $entry) {
-		$ref = $entry->get(PoTokens::REFERENCE);
-		$this->assertCount(count($expected), $ref);
-		$this->assertEquals($expected, $ref);
+	private function assertReferences($expected, $entries) {
+		$refs = array();
+		foreach ($entries as $i => $e) {
+			$refs[$i] = $e->get(PoTokens::REFERENCE);
+		}
+
+		$this->assertEquals($expected, $refs);
 	}
 
 	/**

--- a/tests/data/linenumbers.tpl
+++ b/tests/data/linenumbers.tpl
@@ -1,0 +1,15 @@
+line numbers test
+
+currently seems the line numbers come from closing tag line,
+previous script used starting tag numner.
+
+{t}block on same line{/t}
+
+{t}
+block starts on next, line and ends there{/t}
+
+{t}
+block where start and end and text all on different lines
+{/t}
+
+end


### PR DESCRIPTION
mark the line number based on open tag
this matches behavior of previous parser

