### PR TITLE
nested blocks parsing

### DIFF
--- a/tests/Parser/AssignArgumentTest.php
+++ b/tests/Parser/AssignArgumentTest.php
@@ -16,11 +16,10 @@ namespace SmartyGettext\Test\Parser;
 
 use SmartyGettext\Test\TestCase;
 
-class FunctionArgumentTest extends TestCase
+class AssignArgumentTest extends TestCase
 {
-    public function testTranslationInArgument()
-    {
-        $p = $this->parseTemplate('translation_in_argument_simple.tpl');
+    public function testTranslationInAssign() {
+        $p = $this->parseTemplate('translate_in_assign_simple.tpl');
         $this->assertNotNull($p);
 
         $entries = $p->getPoFile()->getEntries();

--- a/tests/Parser/FunctionArgumentTest.php
+++ b/tests/Parser/FunctionArgumentTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Test\Parser;
+
+use SmartyGettext\Test\TestCase;
+
+class FunctionArgumentTest extends TestCase
+{
+    public function testTranslationInArgument()
+    {
+        $p = $this->parseTemplate('translation_in_argument.tpl');
+        $this->assertNotNull($p);
+
+        $entries = $p->getPoFile()->getEntries();
+        $this->assertCount(1, $entries);
+    }
+}


### PR DESCRIPTION
smarty parses it, tsmarty2c does not:

```smarty
{function name="reply_button" class="" title="" data=""}
{/function}

{reply_button title="{t}reply as email{/t}" class="reply_as_email"}
```