### PR TITLE
add example about bad translation

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -89,6 +89,14 @@ class ParserTest extends TestCase
         $this->assertNotNull($e->get(PoTokens::MESSAGE), "Now with 20% discount!");
     }
 
+    public function testTranslationWithCondition() {
+        $p = $this->parseTemplate(__DIR__ . '/data/translation_with_condition.tpl');
+        $this->assertNotNull($p);
+
+        $entries = $p->getPoFile()->getEntries();
+        $this->assertCount(1, $entries);
+    }
+
     /**
      * Assert that references are equal to expected
      *

--- a/tests/data/translation_with_condition.tpl
+++ b/tests/data/translation_with_condition.tpl
@@ -7,6 +7,65 @@ this is of course better written as:
   {else}
     {t}Thank you, the emails were restored successfully{/t}
   {/if}
+
+while it appears correctly in output,
+sentences should not be split to words according to English language rules.
+
 *}
 
 {t}Thank you, the emails were {if $cat == 'remove'}removed{else}restored{/if} successfully{/t}
+
+{*
+The above gets parsed as:
+
+array:11 [
+  1 => SmartyGettext\Tokenizer\Token\Tag {#47
+    +line: 12
+    +name: "t"
+    +arguments: []
+  }
+  2 => SmartyGettext\Tokenizer\Token\Text {#51
+    +line: 12
+    +text: "Thank you, the emails were "
+  }
+  3 => SmartyGettext\Tokenizer\Token\Tag {#53
+    +line: 12
+    +name: "if"
+    +arguments: []
+  }
+  4 => SmartyGettext\Tokenizer\Token\Text {#57
+    +line: 12
+    +text: "removed"
+  }
+  5 => SmartyGettext\Tokenizer\Token\Tag {#59
+    +line: 12
+    +name: "else"
+    +arguments: []
+  }
+  6 => SmartyGettext\Tokenizer\Token\Text {#62
+    +line: 12
+    +text: "restored"
+  }
+  7 => SmartyGettext\Tokenizer\Token\Tag {#64
+    +line: 12
+    +name: "ifclose"
+    +arguments: []
+  }
+  8 => SmartyGettext\Tokenizer\Token\Text {#67
+    +line: 12
+    +text: " successfully"
+  }
+  9 => SmartyGettext\Tokenizer\Token\Tag {#69
+    +line: 12
+    +name: "tclose"
+    +arguments: []
+  }
+]
+
+and smarty cache:
+
+Thank you, the emails were <?php if ($_smarty_tpl->tpl_vars['cat']->value == 'remove') {?>removed<?php } else { ?>restored<?php
+ }?> successfully<?php $_block_repeat=false;
+echo smarty_block_t(array(), ob_get_clean(), $_smarty_tpl, $_block_repeat);
+
+*}


### PR DESCRIPTION
this just documents that translations should not be made as such:

```smarty
{t}Thank you, the emails were {if $cat == 'remove'}removed{else}restored{/if} successfully{/t}
```

such is not parsed not with old or new tsmarty2c,

and while it appears correctly in output (untranslated),
sentences should not be split to words according to English language rules.

this should be rather written as:
```smarty
  {if $smarty.post.cat == 'remove'}
    {t}Thank you, the emails were removed successfully{/t}
  {else}
    {t}Thank you, the emails were restored successfully{/t}
  {/if}
```

this results two translation keywords, which can be translated properly to other languages