### PR TITLE
fix bogus strip if translation started with quote

### DIFF
--- a/src/PotFile.php
+++ b/src/PotFile.php
@@ -16,6 +16,7 @@ namespace SmartyGettext;
 
 use Geekwright\Po\Exceptions\FileNotWritableException;
 use Smarty;
+use SmartyGettext\Tokenizer\Tag\TranslateTag;
 use SmartyGettext\Tokenizer\TokenParser;
 use Geekwright\Po\Exceptions\FileNotReadableException;
 use Geekwright\Po\PoFile;
@@ -46,15 +47,26 @@ class PotFile
     }
 
     /**
+     * @param string $filename
+     * @return TranslateTag[]
+     * @internal
+     */
+    public function getTags($filename)
+    {
+        return $this->parser->getTranslateTags($filename);
+    }
+
+    /**
      * Load translation tags from $file
      *
      * @param SplFileInfo $file
      */
     public function loadTemplate(SplFileInfo $file)
     {
-        $tags = $this->parser->getTranslateTags($file->getPathname());
-
-        $this->loader->loadTags($tags, $file->getRelativePath());
+        $this->loader->loadTags(
+            $this->getTags($file->getPathname()),
+            $file->getRelativePath()
+        );
     }
 
     /**

--- a/src/TokenLoader.php
+++ b/src/TokenLoader.php
@@ -73,4 +73,25 @@ class TokenLoader extends PoInitSmarty
 
         return $entry;
     }
+
+    /**
+     * Replaces method because parent stripped quote.
+     *
+     * @inheritdoc
+     */
+    public function escapeForPo($string)
+    {
+        // FIXME: is such strip needed anyway?
+        if ($string[0] === '"' || $string[0] === "'") {
+            $len = strlen($string);
+            if ($string[0] === $string[$len - 1]) {
+                $string = substr($string, 1, -1);
+            }
+        }
+
+        $string = str_replace("\r\n", "\n", $string);
+        $string = stripcslashes($string);
+
+        return addcslashes($string, "\0..\37\"");
+    }
 }

--- a/src/Tokenizer/Tag/TranslateTag.php
+++ b/src/Tokenizer/Tag/TranslateTag.php
@@ -104,8 +104,11 @@ class TranslateTag
 
     private function unquote($string)
     {
-        if ($string[0] == '"' || $string[0] == "'") {
-            $string = substr($string, 1, -1);
+        if ($string[0] === '"' || $string[0] === "'") {
+            $len = strlen($string);
+            if ($string[0] === $string[$len-1]) {
+                $string = substr($string, 1, -1);
+            }
         }
 
         return $string;

--- a/src/Tokenizer/Tag/TranslateTag.php
+++ b/src/Tokenizer/Tag/TranslateTag.php
@@ -74,6 +74,14 @@ class TranslateTag
     }
 
     /**
+     * @return string[]
+     */
+    public function getArguments()
+    {
+        return $this->arguments;
+    }
+
+    /**
      * @return string|null
      */
     public function getPlural()
@@ -106,7 +114,7 @@ class TranslateTag
     {
         if ($string[0] === '"' || $string[0] === "'") {
             $len = strlen($string);
-            if ($string[0] === $string[$len-1]) {
+            if ($string[0] === $string[$len - 1]) {
                 $string = substr($string, 1, -1);
             }
         }
@@ -118,9 +126,9 @@ class TranslateTag
     {
         $args = array();
         foreach ($this->arguments as $key => $value) {
-            $args[] = sprintf("%s=%s", $key, var_export($value, 1));
+            $args[] = sprintf('%s=%s', $key, var_export($value, 1));
         }
 
-        return sprintf("{t %s}%s{/t}\n", join(" ", $args), $this->message);
+        return sprintf("{t %s}%s{/t}\n", implode(' ', $args), $this->message);
     }
 }

--- a/tests/Parser/QuoteParserTest.php
+++ b/tests/Parser/QuoteParserTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the smarty-gettext/tsmarty2c package.
+ *
+ * @copyright (c) Elan Ruusamäe
+ * @license BSD
+ * @see https://github.com/smarty-gettext/tsmarty2c
+ *
+ * For the full copyright and license information,
+ * please see the LICENSE and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace SmartyGettext\Test\Parser;
+
+use SmartyGettext\Test\TestCase;
+
+class QuoteParserTest extends TestCase
+{
+    public function testTranslationBeginsWithQuote()
+    {
+        $p = $this->parseTemplate('quotes_in_translation.tpl');
+        $this->assertNotNull($p);
+
+        $entries = $p->getPoFile()->getEntries();
+        $this->assertCount(3, $entries);
+
+        $this->assertArrayHasKey('Note', $entries);
+        $this->assertArrayHasKey("'Note Discussion' is required.", $entries);
+        $this->assertArrayHasKey('\"Email Discussion\" is required.', $entries);
+    }
+}

--- a/tests/Parser/QuoteParserTest.php
+++ b/tests/Parser/QuoteParserTest.php
@@ -14,6 +14,7 @@
 
 namespace SmartyGettext\Test\Parser;
 
+use SmartyGettext\PotFile;
 use SmartyGettext\Test\TestCase;
 
 class QuoteParserTest extends TestCase
@@ -29,5 +30,22 @@ class QuoteParserTest extends TestCase
         $this->assertArrayHasKey('Note', $entries);
         $this->assertArrayHasKey("'Note Discussion' is required.", $entries);
         $this->assertArrayHasKey('\"Email Discussion\" is required.', $entries);
+    }
+
+    public function testArgumentQuotes()
+    {
+        $p = new PotFile();
+        $tags = $p->getTags(__DIR__ . '/../data/argument_quotes.tpl');
+
+        $this->assertCount(1, $tags);
+        $args = $tags[0]->getArguments();
+
+        $exp = array(
+            'quote' => 'bar',
+            'apostrophe' => 'pub',
+            'int' => '1',
+            'bool' => 'false',
+        );
+        $this->assertEquals($exp, $args);
     }
 }

--- a/tests/data/argument_quotes.tpl
+++ b/tests/data/argument_quotes.tpl
@@ -1,0 +1,1 @@
+{t quote="bar" apostrophe='pub' int=1 bool=false}text{/t}

--- a/tests/data/quotes_in_translation.tpl
+++ b/tests/data/quotes_in_translation.tpl
@@ -1,0 +1,2 @@
+<span>{t}Note{/t}: {t}'Note Discussion' is required.{/t}</span>
+<span>{t}Note{/t}: {t}"Email Discussion" is required.{/t}</span>


### PR DESCRIPTION
for example:

```
{t}'Note Discussion' is required.{/t}
```

would be extracted as `Note Discussion' is required`, missing leading apostrophe and trailing dot.