### PR TITLE
add test and example of variables in block content

### DIFF
--- a/tests/SmartyTest.php
+++ b/tests/SmartyTest.php
@@ -64,6 +64,16 @@ class SmartyTest extends TestCase
                 array('direction' => 'up', 'href' => '.'),
                 '<a href="." title="move field up"><i class="fa fa-arrow-up" aria-hidden="true"></i></a>',
             ),
+
+            /*
+             * variables in block content better used as arguments
+             * looks better and parser is able to parse this
+             */
+            'template_vars' => array(
+                'template_vars.tpl',
+                array('issue_id' => 1, 'core' => array('rel_url' => '/')),
+                'View Note Details (Associated with Issue <a href="/view.php?id=1">#1</a>)',
+            ),
         );
     }
 }

--- a/tests/data/template_vars.tpl
+++ b/tests/data/template_vars.tpl
@@ -1,0 +1,11 @@
+{if $issue_id}
+    {t escape=no 1=$issue_id}View Note Details (Associated with Issue <a href="{$core.rel_url}view.php?id=%1">#%1</a>){/t}
+{else}
+    {t}View Note Details{/t}
+{/if}
+
+{*
+this doesn't parse well, use this instead:
+
+{t escape=no 1=$issue_id 2="{$core.rel_url}view.php?id=$issue_id"}View Note Details (Associated with Issue <a href="%2">#%1</a>){/t}
+*}


### PR DESCRIPTION
variables in block content better used as arguments
looks better and parser is able to parse this.

```smarty
{if $issue_id}
    {t escape=no 1=$issue_id}View Note Details (Associated with Issue <a href="{$core.rel_url}view.php?id=%1">#%1</a>){/t}
{else}
    {t}View Note Details{/t}
{/if}
```
this doesn't parse well, use this instead:
```smarty
{t escape=no 1=$issue_id 2="{$core.rel_url}view.php?id=$issue_id"}View Note Details (Associated with Issue <a href="%2">#%1</a>){/t}
```
otherwise the translation keyword is dynamic, impossible to translate.