### PR TITLE
Smarty 3.1.35 introduced BC break, so reject it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
 		"geekwright/po": "^1.0",
 		"php": "^5.5.9 || ^7.0",
 		"smarty-gettext/smarty-gettext": "^1.5.0",
-		"smarty/smarty": "^3.1.31",
+		"smarty/smarty": "<3.1.35",
 		"symfony/console": "^3.2",
 		"symfony/finder": "^2.8|^3.0"
 	},


### PR DESCRIPTION
Something in Smarty 3.1.35 and 3.1.36 made Token parser not to see text nodes.

So reject those versions for now.