### PR TITLE
Fix Symfony 5 compatibility

### DIFF
--- a/src/Console/Command/Extract.php
+++ b/src/Console/Command/Extract.php
@@ -58,7 +58,7 @@ EOT
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return void
+     * @return int
      * @throws FileNotReadableException
      * @throws FileNotWritableException
      * @throws InvalidArgumentException
@@ -92,6 +92,7 @@ EOT
         }
 
         $output->writeln('<info>Done</info>');
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Updates to return int in execute() for Symfony 5 compatiblity.

Fixes #18
Refs:
- https://github.com/symfony/symfony/issues/33747